### PR TITLE
Set stability to 0 if n_clusters == n_spectra

### DIFF
--- a/src/cnmf/cnmf.py
+++ b/src/cnmf/cnmf.py
@@ -787,7 +787,10 @@ class cNMF():
         median_spectra = (median_spectra.T/median_spectra.sum(1)).T
 
         # Compute the silhouette score
-        stability = silhouette_score(l2_spectra.values, kmeans_cluster_labels, metric='euclidean')
+        if len(np.unique(kmeans_cluster_labels)) == len(kmeans_cluster_labels):
+            stability = 0
+        else:
+            stability = silhouette_score(l2_spectra.values, kmeans_cluster_labels, metric='euclidean')
 
         # Obtain reconstructed count matrix by re-fitting usage and computing dot product: usage.dot(spectra)
         rf_usages = self.refit_usage(norm_counts.X, median_spectra)


### PR DESCRIPTION
silhouette sometimes throws an error in n_clusters == n_spectra.
```pytb
  File "/home/runner/work/immunaISR/immunaISR/immunaisr/methods/methods/consensus_nmf.py", line 126, in _consensus
    self.cnmf_op.consensus(
  File "/opt/hostedtoolcache/Python/3.8.17/x64/lib/python3.8/site-packages/cnmf/cnmf.py", line 791, in consensus
    stability = silhouette_score(l2_spectra.values, kmeans_cluster_labels, metric='euclidean')
  File "/opt/hostedtoolcache/Python/3.8.17/x64/lib/python3.8/site-packages/sklearn/metrics/cluster/_unsupervised.py", line 117, in silhouette_score
    return np.mean(silhouette_samples(X, labels, metric=metric, **kwds))
  File "/opt/hostedtoolcache/Python/3.8.17/x64/lib/python3.8/site-packages/sklearn/metrics/cluster/_unsupervised.py", line 231, in silhouette_samples
    check_number_of_labels(len(le.classes_), n_samples)
  File "/opt/hostedtoolcache/Python/3.8.17/x64/lib/python3.8/site-packages/sklearn/metrics/cluster/_unsupervised.py", line 33, in check_number_of_labels
    raise ValueError(
ValueError: Number of labels is 64. Valid values are 2 to n_samples - 1 (inclusive)
```